### PR TITLE
Add initial .NET 8 console application

### DIFF
--- a/IonicsConsole/IonicsConsole.csproj
+++ b/IonicsConsole/IonicsConsole.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Npgsql" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/IonicsConsole/Program.cs
+++ b/IonicsConsole/Program.cs
@@ -1,0 +1,28 @@
+using IonicsConsole.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Configuration
+    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+    .AddEnvironmentVariables()
+    .AddCommandLine(args);
+
+builder.Services.AddHttpClient<ApiClient>();
+
+builder.Services.AddSingleton<NpgsqlDataSource>(sp =>
+{
+    var connString = builder.Configuration.GetConnectionString("Default");
+    return new NpgsqlDataSourceBuilder(connString).Build();
+});
+
+builder.Services.AddSingleton<JobService>();
+
+using var host = builder.Build();
+
+var job = host.Services.GetRequiredService<JobService>();
+await job.RunAsync();

--- a/IonicsConsole/Services/ApiClient.cs
+++ b/IonicsConsole/Services/ApiClient.cs
@@ -1,0 +1,56 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Configuration;
+
+namespace IonicsConsole.Services;
+
+public class ApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly IConfiguration _config;
+
+    public ApiClient(HttpClient httpClient, IConfiguration config)
+    {
+        _httpClient = httpClient;
+        _config = config;
+    }
+
+    public async Task<AuthResponse?> LoginAsync()
+    {
+        var payload = new
+        {
+            clientId = _config["ClientId"],
+            clientSecret = _config["ClientSecret"]
+        };
+
+        var url = $"{_config["BaseUrl"]}{_config["AuthEndpoint"]}";
+        var resp = await _httpClient.PostAsJsonAsync(url, payload);
+        if (!resp.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        return await resp.Content.ReadFromJsonAsync<AuthResponse>();
+    }
+
+    public async Task<bool> SendDataAsync(string token, IEnumerable<Dictionary<string, object>> records, int offset, int customerId, string clientId)
+    {
+        var url = $"{_config["BaseUrl"]}{_config["WriterEndpoint"]}";
+        var req = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(new { records })
+        };
+        req.Headers.Add("Authorization", $"Bearer {token}");
+        req.Headers.Add("CustomerID", customerId.ToString());
+        req.Headers.Add("ClientID", clientId);
+        req.Headers.Add("DeleteData", offset == 0 ? "1" : "0");
+
+        var resp = await _httpClient.SendAsync(req);
+        if (!resp.IsSuccessStatusCode) return false;
+        var body = await resp.Content.ReadFromJsonAsync<SendDataResponse>();
+        return body?.Message == "success";
+    }
+}
+
+public record User(int Id, string Name, string ClientId, int CustomerId, string Role);
+public record AuthResponse(string Message, User User, string Token);
+public record SendDataResponse(string Message);

--- a/IonicsConsole/Services/JobService.cs
+++ b/IonicsConsole/Services/JobService.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+
+namespace IonicsConsole.Services;
+
+public class JobService
+{
+    private readonly ApiClient _client;
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly ILogger<JobService> _logger;
+    private readonly int _batchSize;
+    private readonly string _initialDate;
+
+    public JobService(ApiClient client, NpgsqlDataSource dataSource, IConfiguration config, ILogger<JobService> logger)
+    {
+        _client = client;
+        _dataSource = dataSource;
+        _logger = logger;
+        _batchSize = config.GetValue<int>("BatchSize", 30);
+        _initialDate = config.GetValue("InitialDate", DateTime.UtcNow.ToString("yyyy-MM-dd"));
+    }
+
+    public async Task RunAsync(CancellationToken token = default)
+    {
+        _logger.LogInformation("Running job...");
+
+        var login = await _client.LoginAsync();
+        if (login?.Token == null)
+        {
+            _logger.LogWarning("Failed to authenticate");
+            return;
+        }
+
+        await using var conn = await _dataSource.OpenConnectionAsync(token);
+        int offset = 0;
+        while (!token.IsCancellationRequested)
+        {
+            var records = await LoadRecordsAsync(conn, offset, token);
+            if (records.Count == 0)
+            {
+                _logger.LogInformation("Process completed");
+                break;
+            }
+
+            var sent = await _client.SendDataAsync(login.Token, records, offset, login.User.CustomerId, login.User.ClientId);
+            if (!sent)
+            {
+                _logger.LogWarning("Failed to send records to API");
+                break;
+            }
+
+            offset += _batchSize;
+        }
+    }
+
+    private async Task<List<Dictionary<string, object>>> LoadRecordsAsync(NpgsqlConnection conn, int offset, CancellationToken token)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"SELECT * FROM your_table LIMIT @batch OFFSET @offset"; // replace with real query
+        cmd.Parameters.AddWithValue("batch", _batchSize);
+        cmd.Parameters.AddWithValue("offset", offset);
+
+        await using var reader = await cmd.ExecuteReaderAsync(token);
+        var list = new List<Dictionary<string, object>>();
+        while (await reader.ReadAsync(token))
+        {
+            var record = new Dictionary<string, object>();
+            for (int i = 0; i < reader.FieldCount; i++)
+            {
+                record[reader.GetName(i)] = await reader.IsDBNullAsync(i, token) ? null : reader.GetValue(i);
+            }
+            list.Add(record);
+        }
+        return list;
+    }
+}

--- a/IonicsConsole/appsettings.json
+++ b/IonicsConsole/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "BaseUrl": "http://127.0.0.1:3333",
+  "AuthEndpoint": "/auth/login",
+  "WriterEndpoint": "/v1/writer",
+  "ClientId": "AC6CB1CB6A594EAFA8D9009ED01C0233",
+  "ClientSecret": "c4c574780cab4b22bf8e69629992bc69",
+  "BatchSize": 30,
+  "InitialDate": "2024-07-01",
+  "ConnectionStrings": {
+    "Default": "Host=127.0.0.1;Port=5432;Username=dev;Password=dev;Database=pgsql"
+  }
+}


### PR DESCRIPTION
## Summary
- set up a basic console application in C# targeting .NET 8
- include configuration handling and project file
- create `ApiClient` and `JobService` services to mimic Go logic
- provide example `appsettings.json`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e8df2bf948325a31cab2ee38e815b